### PR TITLE
Conditionally build with MPL and BSD2 support.

### DIFF
--- a/src/Debian/Policy.hs
+++ b/src/Debian/Policy.hs
@@ -359,14 +359,16 @@ fromCabalLicense x =
       Cabal.GPL mver -> GPL -- FIXME - what about the version number?  same below
       Cabal.AGPL mver -> OtherLicense (show x)
       Cabal.LGPL mver -> LGPL
-      Cabal.BSD2 -> BSD_2_Clause
       Cabal.BSD3 -> BSD_3_Clause
       Cabal.BSD4 -> BSD_4_Clause
       Cabal.MIT -> OtherLicense (show x)
-      Cabal.MPL ver -> MPL
       Cabal.Apache mver -> Apache
       Cabal.PublicDomain -> Public_Domain
       Cabal.AllRightsReserved -> OtherLicense "AllRightsReserved"
+#if MIN_VERSION_Cabal(1,19,2)
+      Cabal.BSD2 -> BSD_2_Clause
+      Cabal.MPL ver -> MPL
+#endif
 #if MIN_VERSION_Cabal(1,21,1)
       Cabal.UnspecifiedLicense -> OtherLicense (show x)
 #endif
@@ -377,7 +379,9 @@ toCabalLicense :: License -> Cabal.License
 toCabalLicense x =
     -- This needs to be finished
     case x of
+#if MIN_VERSION_Cabal(1,19,2)
       BSD_2_Clause -> Cabal.BSD2
+#endif
       BSD_3_Clause -> Cabal.BSD3
       BSD_4_Clause -> Cabal.BSD4
       OtherLicense s -> Cabal.UnknownLicense s


### PR DESCRIPTION
@nomeata This is the error I was receiving.

```
$ cabal build
Building cabal-debian-4.19...
Preprocessing library cabal-debian-4.19...
[11 of 28] Compiling Debian.Policy    ( src/Debian/Policy.hs, dist/build/Debian/Policy.o )

src/Debian/Policy.hs:362:7:
    Not in scope: data constructor ‘Cabal.BSD2’
    Perhaps you meant one of these:
      ‘Cabal.BSD3’ (imported from Distribution.License),
      ‘Cabal.BSD4’ (imported from Distribution.License)

src/Debian/Policy.hs:366:7:
    Not in scope: data constructor ‘Cabal.MPL’
    Perhaps you meant one of these:
      ‘Cabal.GPL’ (imported from Distribution.License),
      ‘Cabal.AGPL’ (imported from Distribution.License),
      ‘Cabal.LGPL’ (imported from Distribution.License)

src/Debian/Policy.hs:380:23:
    Not in scope: data constructor ‘Cabal.BSD2’
    Perhaps you meant one of these:
      ‘Cabal.BSD3’ (imported from Distribution.License),
      ‘Cabal.BSD4’ (imported from Distribution.License)
```

MPL and BSD2 support was added in Cabal 1.19.2, Here are some commits:

https://github.com/haskell/cabal/commit/1e534
https://github.com/haskell/cabal/commit/cdc24
https://github.com/haskell/cabal/commit/0a65decc

Hope this helps, I'll be happy to fix any other issues here.
