### PR TITLE
Add travis build file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: haskell
+before_install:
+env:
+ - GHCVER=7.4.2 CABALVER=1.18
+ - GHCVER=7.6.3 CABALVER=1.18
+ - GHCVER=7.8.4 CABALVER=1.18
+ - GHCVER=7.10.1 CABALVER=1.22
+ - GHCVER=head  CABALVER=head
+
+matrix:
+  allow_failures:
+   - env: GHCVER=7.10.1 CABALVER=1.22
+   - env: GHCVER=head  CABALVER=head
+
+before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
+ - cabal --version
+ - cabal install happy alex
+
+install:
+ - travis_retry cabal update
+ - cabal install --only-dependencies --enable-tests
+
+script:
+ - cabal configure --enable-tests
+#--enable-library-coverage || cabal configure --enable-tests --enable-coverage
+ - cabal build
+ - cabal test
+
+#after_script:
+# - cabal install hpc-coveralls
+# - hpc-coveralls --exclude-dir=test test


### PR DESCRIPTION
This build file will "allow" failures on ghc-7.10 and ghc HEAD. This might help migrate and prepare cabal-debian for new releases.

All you need to do is log in to travis and enable builds on this repository. Travis is tightly integrated with github so it should "just work" (You can just use your github credentials).