### PR TITLE
Fix to generate shlibs:Depends for -utils packages

### DIFF
--- a/src/Debian/Debianize/Finalize.hs
+++ b/src/Debian/Debianize/Finalize.hs
@@ -411,6 +411,8 @@ binaryPackageRelations b typ = zoom A.debInfo $ do
     when (typ == B.Development) $ do
       B.depends %= (edds ++)
       B.depends %= (anyrel "${shlibs:Depends}" : )
+    when (typ == B.Utilities) $
+      B.depends %= (anyrel "${shlibs:Depends}" : )
     B.depends    %= ([anyrel "${haskell:Depends}", anyrel "${misc:Depends}"] ++)
     B.recommends %= (anyrel "${haskell:Recommends}" : )
     B.suggests   %= (anyrel "${haskell:Suggests}" :)


### PR DESCRIPTION
This fix is reported in following message.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=866375